### PR TITLE
Added +2 spd to mana concealment for Fern

### DIFF
--- a/src/data/decks/fern.ts
+++ b/src/data/decks/fern.ts
@@ -41,11 +41,11 @@ const disapprovingPout = new Card({
 export const manaConcealment = new Card({
     title: "Mana Concealment",
     cardMetadata: { nature: Nature.Util },
-    description: ([atk, def]) =>
-        `ATK+${atk}. DEF+${def}. Receive Priority+1 and additional 50% Pierce on attacks for next turn.`,
+    description: ([atk, def, spd]) =>
+        `ATK+${atk}. DEF+${def}. SPD+${spd} Receive Priority+1 and additional 50% Pierce on attacks for next turn.`,
     emoji: CardEmoji.FERN_CARD,
-    effects: [1, 2],
-    effectNames: ["ATK", "DEF"],
+    effects: [1, 2, 2],
+    effectNames: ["ATK", "DEF", "SPD"],
     cardCategories: ["Utility"],
     deck: "fern",
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Mana Concealment" card now displays and applies a Speed (SPD) effect in addition to Attack (ATK) and Defense (DEF).

- **Bug Fixes**
  - Updated the card description to accurately reflect all effects, including the new SPD value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->